### PR TITLE
Change `getSessionKey` to public method

### DIFF
--- a/modules/cbstorages/models/CacheStorage.cfc
+++ b/modules/cbstorages/models/CacheStorage.cfc
@@ -144,7 +144,7 @@ component accessors="true" threadsafe singleton{
 	/**
 	* Builds the unique Session Key of a user request
 	*/
-	private string function getSessionKey(){
+	public string function getSessionKey(){
 		var prefix = "cbstorage:#variables.appName#:";
 
 		// Check jsession id First


### PR DESCRIPTION
When using the cache storage provider for login storage, public access to this method will allow for logging out of a user which is not the current user by providing access to evict an individual key.

This is helpful when changing role/permission assignments, which may require the user to log back in.