### PR TITLE
Remove numeric typing on exipiry

### DIFF
--- a/models/CookieStorage.cfc
+++ b/models/CookieStorage.cfc
@@ -94,7 +94,7 @@ component
 	CookieStorage function set(
 		required name,
 		required value,
-		numeric expires=0,
+		any expires=0,
 		boolean secure=variables.secure,
 		string path="",
 		string domain=variables.domain,


### PR DESCRIPTION
The numeric typing on the `expires` argument will still allow a date object to pass through ( strangely ), but prevents the pass through of the textual arguments allowed by CFCookie:

https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-c/cfcookie.html

Removing strong typing on arg.