### PR TITLE
Update AbstractStorage.cfc

### DIFF
--- a/models/AbstractStorage.cfc
+++ b/models/AbstractStorage.cfc
@@ -41,9 +41,9 @@ component
 		}
 
 		// else, produce it
-		lock name="getOrSet.#variables.lockName#.#arguments.name#" type="exclusive" timeout="#variables.timeout#" throwonTimeout="true"{
+		lock name="getOrSet.#variables.lockName#.#arguments.name#" type="exclusive" timeout="#variables.lockTimeout#" throwonTimeout="true"{
 			// double lock, due to race conditions
-			var target = get( arguments.objectKey );
+			var target = get( arguments.name );
 			if( isNull( local.target ) ){
 				// produce it
 				target = arguments.produce();


### PR DESCRIPTION
fix 2 bugs in getOrSet. there is no variables.timeout, I think it should be variables.lockTimeout.
and there's also no arguments.objectKey. Should be arguments.name