### PR TITLE
changed expires default

### DIFF
--- a/models/CookieStorage.cfc
+++ b/models/CookieStorage.cfc
@@ -94,7 +94,7 @@ component
 	CookieStorage function set(
 		required name,
 		required value,
-		any expires=0,
+		any expires,
 		boolean secure=variables.secure,
 		string path="",
 		string domain=variables.domain,
@@ -116,9 +116,12 @@ component
 			"name" 		: arguments.name,
 			"value"		: tmpValue,
 			"secure"	: arguments.secure,
-			"expires"	: arguments.expires,
 			"httpOnly"	: arguments.httpOnly
 		};
+		//only add expires if existing in arguments to mimic default cookie behaviour
+		if ( structKeyExists(arguments,"expires")) {
+			args[ "expires" ] = arguments.expires;
+		}
 
 		// Domain + path info
 		if( len( arguments.path ) && !len( arguments.domain ) ){

--- a/models/CookieStorage.cfc
+++ b/models/CookieStorage.cfc
@@ -119,7 +119,7 @@ component
 			"httpOnly"	: arguments.httpOnly
 		};
 		//only add expires if existing in arguments to mimic default cookie behaviour
-		if ( structKeyExists(arguments,"expires")) {
+		if ( !isNull( arguments.expires ) ) {
 			args[ "expires" ] = arguments.expires;
 		}
 


### PR DESCRIPTION
expires=0 will make sure a cookie is not stored. Not a nice default for a 'set'  command. If you don't specify expires in cfcookie it will stay valid for the current session.
That's what I added as a default now. It only add expires to cfcookie if it is defined in the arguments.