### PR TITLE
Add param for identifier provider

### DIFF
--- a/models/CacheStorage.cfc
+++ b/models/CacheStorage.cfc
@@ -46,6 +46,7 @@ component
 		// Get application name
 		variables.appName  = application.applicationName;
 		// Store module settings
+		param arguments.settings.identifierProvider = "";
 		variables.settings = arguments.settings;
 		// Default timeout
 		variables.timeout  = arguments.settings.cacheStorage.timeout;

--- a/models/CacheStorage.cfc
+++ b/models/CacheStorage.cfc
@@ -44,14 +44,14 @@ component
 	 */
 	function init( required settings, required cachebox ){
 		// Get application name
-		variables.appName  = application.applicationName;
+		variables.appName                           = application.applicationName;
 		// Store module settings
 		param arguments.settings.identifierProvider = "";
-		variables.settings = arguments.settings;
+		variables.settings                          = arguments.settings;
 		// Default timeout
-		variables.timeout  = arguments.settings.cacheStorage.timeout;
+		variables.timeout                           = arguments.settings.cacheStorage.timeout;
 		// Assemble Provider
-		variables.cache    = arguments.cachebox.getCache( variables.settings.cacheStorage.cachename );
+		variables.cache                             = arguments.cachebox.getCache( variables.settings.cacheStorage.cachename );
 
 		return this;
 	}


### PR DESCRIPTION
This prevents v2.6.x from breaking previous custom configurations for cbStorages.cacheStorage