### PR TITLE
Cookie should only be set once

### DIFF
--- a/models/CookieStorage.cfc
+++ b/models/CookieStorage.cfc
@@ -145,7 +145,6 @@ component
 			args[ "domain" ] = arguments.domain;
 		}
 
-		cookie[ arguments.name ] = tmpValue;
 		cfcookie( attributeCollection = args );
 
 		return this;


### PR DESCRIPTION
Cookie is being set twice
Appears twice in response headers when the `samesite` parameter is passed, one of them does not have the attributes (only the value)

**Example to reproduce:**

Code: `CookieStorage.set( name="TEST_COOKIE", value=getTickCount(), samesite="Strict" );`

Environment: ACF 2018 u16

Browser: Chrome

**Response Headers:**

<img width="740" alt="226898543-76274ed8-bc4a-4ff5-8c91-2bbf3a418d03" src="https://user-images.githubusercontent.com/148847/227192078-6efa4452-7a9f-4137-af2f-e15cfcf15ab9.png">

Cookie stored as:

(note that the httpOnly / Secure / SameSite attributes are not set)

<img width="1037" alt="226900734-9e3992e8-bd10-4e24-9cc4-a98019045e27" src="https://user-images.githubusercontent.com/148847/227192107-16881451-8a84-4881-b9a6-e362b3ec4079.png">

